### PR TITLE
Fix default uuid to int projection

### DIFF
--- a/src/main/scala/toguru/impl/Conditions.scala
+++ b/src/main/scala/toguru/impl/Conditions.scala
@@ -49,11 +49,6 @@ object UuidDistributionCondition {
 
   val defaultUuidToIntProjection: UUID => Int = {
     (uuid) =>
-      val hibits = uuid.getMostSignificantBits
-      val lobits = uuid.getLeastSignificantBits
-      val barrayHi = BigInteger.valueOf(hibits).toByteArray
-      val barrayLo = BigInteger.valueOf(lobits).toByteArray
-      val comb = barrayLo ++ barrayHi
-      Math.abs(new BigInteger(comb).mod(BigInteger.valueOf(100l)).intValue()) + 1
+      new BigInteger(uuid.toString().replace('-', ''), 16).mod(BigInteger.valueOf(100l)).intValue() + 1
   }
 }


### PR DESCRIPTION
IMHO the default projection should be to calculate (uuid modulo 100) + 1 without any tricks. This would allow any technology to recreate this logic for compatibility reasons.

PS: some tests will fail, please fix them before merging. Thanks.