### PR TITLE
Fix/extend ToggleStateActivations.togglesFor method and add related tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ scala:
 - 2.12.3
 
 jdk:
-- oraclejdk8
+- openjdk8
 
 script:
 - sbt ++$TRAVIS_SCALA_VERSION clean coverage test package coverageReport

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.5.0")
 
 addSbtPlugin("org.scoverage" %% "sbt-coveralls" % "1.1.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")

--- a/src/main/scala/toguru/api/Toggling.scala
+++ b/src/main/scala/toguru/api/Toggling.scala
@@ -34,14 +34,15 @@ trait Toggling {
     *                the toguru server.
     * @return
     */
-  @deprecated("It will be removed, use apply(s: String) instead", "1.0.2")
   def toggleStringForService(service: String): String = {
-    // $COVERAGE-OFF$Disabled because it's deprecated
-    val toggleStates = activations.togglesFor(service)
-      .map { case (id, c) => id -> client.forcedToggle(id).getOrElse(c.applies(client))}
+    val toggleStates =
+      activations
+        .togglesFor(service)
+        .map { case (toggleId, condition) =>
+          toggleId -> client.forcedToggle(toggleId).getOrElse(condition.applies(client))
+        }
 
     TogglesString.build(toggleStates)
-    // $COVERAGE-ON$
   }
 }
 

--- a/src/main/scala/toguru/api/Toggling.scala
+++ b/src/main/scala/toguru/api/Toggling.scala
@@ -30,7 +30,7 @@ trait Toggling {
   /**
     * Returns a toggling string for downstream services.
     *
-    * @param service the name of the downstream service - must match the "services" tag defined on the toggle on
+    * @param service the name of the downstream service - must match the "service" tag or be included in the "services" tag defined on the toggle on
     *                the toguru server.
     * @return
     */

--- a/src/test/scala/toguru/impl/ToggleStateSpec.scala
+++ b/src/test/scala/toguru/impl/ToggleStateSpec.scala
@@ -15,7 +15,13 @@ class ToggleStateSpec extends WordSpec with MustMatchers with MockitoSugar {
     ToggleState("toggle1", Map("services" -> "toguru"), activation(rollout(30))),
     ToggleState("toggle-2", Map.empty[String, String], activation(rollout(100))),
     ToggleState("toggle-4", Map.empty[String, String], activation(attrs = Map("culture" -> Seq("DE", "de-DE"), "version" -> Seq("1", "2")))),
-    ToggleState("toggle-5", Map.empty[String, String], activation(rollout(30), attrs = Map("culture" -> Seq("DE", "de-DE"), "version" -> Seq("1", "2")))))
+    ToggleState("toggle-5", Map.empty[String, String], activation(rollout(30), attrs = Map("culture" -> Seq("DE", "de-DE"), "version" -> Seq("1", "2")))),
+    ToggleState("toggle6", Map("services" -> "my-service,another-service"), activation(rollout(15))),
+    ToggleState("toggle7", Map("services" -> "my-service "), activation(rollout(1))),
+    ToggleState("toggle8", Map("service" -> " my-service"), activation(rollout(100))),
+    ToggleState("toggle9", Map("services" -> "another-service,yet-another-service,my-service"), activation()),
+    ToggleState("toggle10", Map("services" -> "another-service, my-service, yet-another-service"), activation())
+  )
 
 
   "ToggleState.apply" should {
@@ -63,6 +69,13 @@ class ToggleStateSpec extends WordSpec with MustMatchers with MockitoSugar {
       val uuidCondition = condition.asInstanceOf[UuidDistributionCondition]
 
       uuidCondition.ranges mustBe List(1 to 30)
+    }
+
+    "return all toggle activations for a service" in {
+      val toguruToggles = activations.togglesFor("my-service")
+
+      toguruToggles must have size 5
+      toguruToggles.keySet mustBe Set("toggle6", "toggle7", "toggle8", "toggle9", "toggle10")
     }
 
     "return toggle default conditions if toggle is unknown" in {


### PR DESCRIPTION
This is a PR which changes the `ToggleStateActivations.togglesFor` method:
- to accept multiple services in `services` tag (split by `,`) 
- and a new `service` tag with a single service (since many toggles are already configured this way).
- It is intended to be backward-compatible
- It removes the deprecation for `toggleStringForService` since this has its use cases (for example we can use it instead of [this](https://github.com/Scout24/classified-detail/blob/9cb79da612fcba291247f36112e6c287417fb3a0/app/classifieddetail/toguru/Toggles.scala#L99) )