### PR TITLE
Use sbt-git-versioning instead of sbt-git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ after_success:
   - sbt ++$TRAVIS_SCALA_VERSION coveralls
   - >
     if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_REPO_SLUG" = "Scout24/toguru-scala-client" ]; then
-      if [ "$TRAVIS_BRANCH" == "master" ] || [[ $TRAVIS_TAG ]]; then
+      if [[ $TRAVIS_TAG ]]; then
         ./publish-bintray-release.sh;
       fi
     fi

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ scalaVersion in ThisBuild := "2.11.8"
 scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation", "-feature", "-Xfatal-warnings",
   "-Yno-adapted-args", "-Xmax-classfile-name", "130")
 
-resolvers += Resolver.jcenterRepo
+resolvers ++= Seq(Resolver.jcenterRepo, Resolver.bintrayRepo("autoscout24", "maven"))
 
 libraryDependencies in ThisBuild ++= Seq(
   "org.scalaj" %% "scalaj-http" % "2.3.0",

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
-lazy val root = project.in(file(".")).enablePlugins(GitVersioning)
+lazy val root = project.in(file(".")).enablePlugins(SemVerPlugin)
 
 name := "toguru-scala-client"
-
-git.baseVersion := "1.1.1"
 
 organization in ThisBuild := "com.autoscout24"
 licenses += ("MIT", url("http://opensource.org/licenses/MIT"))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version=1.3.4
+# newer sbt version cannot be used because of https://github.com/rallyhealth/sbt-git-versioning/issues/16
+sbt.version=1.3.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,7 @@ addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.6.1")
 
 addSbtPlugin("org.scoverage" %% "sbt-coveralls" % "1.2.7")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+resolvers += Resolver.bintrayIvyRepo("rallyhealth", "sbt-plugins")
+addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % "1.2.2")
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")


### PR DESCRIPTION
Benefits:
 - Proper version bumps (e.g. currently it will be `2.0.1-xxx` because the last tag is `2.0.0`)
 - SemVer checks happen automatically when running tests

I disabled publishing for every commit on master because mixing released and "snapshot" artifacts is not nice. It also used to break the "latest version" badge in the readme.
