### PR TITLE
Reformat sources with scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,10 @@
+version = 2.3.2
+style   = defaultWithAlign
+
+project.git                      = true
+maxColumn                        = 120
+danglingParentheses              = true
+rewrite.rules                    = [RedundantBraces, RedundantParens, AvoidInfix, SortImports]
+importSelectors                  = singleLine
+assumeStandardLibraryStripMargin = true
+trailingCommas                   = preserve

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jdk:
 - openjdk8
 
 script:
-- sbt ++$TRAVIS_SCALA_VERSION clean coverage test package coverageReport
+- sbt ++$TRAVIS_SCALA_VERSION clean coverage formatCheck test package coverageReport
 - sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
 # Trick to avoid unnecessary cache updates
 - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/build.sbt
+++ b/build.sbt
@@ -11,23 +11,30 @@ crossScalaVersions in ThisBuild := Seq("2.12.3", "2.11.8")
 
 scalaVersion in ThisBuild := "2.11.8"
 
-scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation", "-feature", "-Xfatal-warnings",
-  "-Yno-adapted-args", "-Xmax-classfile-name", "130")
+scalacOptions in ThisBuild ++= Seq(
+  "-unchecked",
+  "-deprecation",
+  "-feature",
+  "-Xfatal-warnings",
+  "-Yno-adapted-args",
+  "-Xmax-classfile-name",
+  "130"
+)
 
 resolvers ++= Seq(Resolver.jcenterRepo, Resolver.bintrayRepo("autoscout24", "maven"))
 
 libraryDependencies in ThisBuild ++= Seq(
-  "org.scalaj" %% "scalaj-http" % "2.3.0",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
-  "commons-io" % "commons-io" % "2.4",
-  "io.dropwizard.metrics" % "metrics-core" % "3.1.0",
-  "org.komamitsu" % "phi-accural-failure-detector" % "0.0.3",
-  "org.scalactic" %% "scalactic" % "3.0.3",
-  "com.hootsuite" %% "scala-circuit-breaker" % "1.0.2",
-  "org.mockito" % "mockito-core" % "2.0.8-beta" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.3" % "test",
-  "org.http4s" %% "http4s-dsl" % "0.17.0-M3" % "test",
-  "org.http4s" %% "http4s-blaze-server" % "0.17.0-M3" % "test"
+  "org.scalaj"                 %% "scalaj-http"                 % "2.3.0",
+  "com.typesafe.scala-logging" %% "scala-logging"               % "3.5.0",
+  "commons-io"                 % "commons-io"                   % "2.4",
+  "io.dropwizard.metrics"      % "metrics-core"                 % "3.1.0",
+  "org.komamitsu"              % "phi-accural-failure-detector" % "0.0.3",
+  "org.scalactic"              %% "scalactic"                   % "3.0.3",
+  "com.hootsuite"              %% "scala-circuit-breaker"       % "1.0.2",
+  "org.mockito"                % "mockito-core"                 % "2.0.8-beta" % "test",
+  "org.scalatest"              %% "scalatest"                   % "3.0.3" % "test",
+  "org.http4s"                 %% "http4s-dsl"                  % "0.17.0-M3" % "test",
+  "org.http4s"                 %% "http4s-blaze-server"         % "0.17.0-M3" % "test"
 )
 
 libraryDependencies := {
@@ -35,13 +42,13 @@ libraryDependencies := {
     case Some((2, 12)) =>
       libraryDependencies.value ++ Seq(
         "com.typesafe.play" %% "play-json" % "2.6.1",
-        "com.typesafe.play" %% "play" % "2.6.1" % "optional",
+        "com.typesafe.play" %% "play"      % "2.6.1" % "optional",
         "com.typesafe.play" %% "play-test" % "2.6.1" % "optional"
       )
     case _ =>
       libraryDependencies.value ++ Seq(
         "com.typesafe.play" %% "play-json" % "2.5.4",
-        "com.typesafe.play" %% "play" % "2.5.4" % "optional",
+        "com.typesafe.play" %% "play"      % "2.5.4" % "optional",
         "com.typesafe.play" %% "play-test" % "2.5.4" % "optional"
       )
   }
@@ -52,7 +59,7 @@ scoverage.ScoverageKeys.coverageFailOnMinimum := true
 
 resolvers in ThisBuild ++= Seq(
   Classpaths.sbtPluginReleases,
-  "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
+  "Typesafe repository".at("https://repo.typesafe.com/typesafe/releases/")
 )
 
 addCommandAlias("format", "; scalafmt; test:scalafmt; scalafmtSbt")

--- a/build.sbt
+++ b/build.sbt
@@ -54,3 +54,6 @@ resolvers in ThisBuild ++= Seq(
   Classpaths.sbtPluginReleases,
   "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 )
+
+addCommandAlias("format", "; scalafmt; test:scalafmt; scalafmtSbt")
+addCommandAlias("formatCheck", "; scalafmtCheck; test:scalafmtCheck; scalafmtSbtCheck")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,3 +8,5 @@ resolvers += Resolver.bintrayIvyRepo("rallyhealth", "sbt-plugins")
 addSbtPlugin("com.rallyhealth.sbt" % "sbt-git-versioning" % "1.2.2")
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
+
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.0")

--- a/src/main/scala-2.11/toguru/play/PlaySupport.scala
+++ b/src/main/scala-2.11/toguru/play/PlaySupport.scala
@@ -66,8 +66,7 @@ object PlaySupport extends AbstractPlaySupport {
     * @param toguruClient the play toguru client to use
     * @return
     */
-  def ToggledAction(
-      toguruClient: PlayToguruClient): ActionBuilder[ToggledRequest] =
-    Action andThen new TogglingRefiner(toguruClient)
+  def ToggledAction(toguruClient: PlayToguruClient): ActionBuilder[ToggledRequest] =
+    Action.andThen(new TogglingRefiner(toguruClient))
 
 }

--- a/src/main/scala-2.11/toguru/play/TogglingRefiner.scala
+++ b/src/main/scala-2.11/toguru/play/TogglingRefiner.scala
@@ -17,12 +17,8 @@ override val activations = toguru.activationsProvider()
   *
   * @param toguruClient the toguru client to use.
   */
-class TogglingRefiner(toguruClient: PlayToguruClient)
-    extends ActionRefiner[Request, ToggledRequest] {
+class TogglingRefiner(toguruClient: PlayToguruClient) extends ActionRefiner[Request, ToggledRequest] {
   def refine[A](request: Request[A]) = Future.successful {
-    Right(
-      new ToggledRequest[A](toguruClient.clientProvider(request),
-                            toguruClient.activationsProvider(),
-                            request))
+    Right(new ToggledRequest[A](toguruClient.clientProvider(request), toguruClient.activationsProvider(), request))
   }
 }

--- a/src/main/scala-2.12/toguru/play/PlaySupport.scala
+++ b/src/main/scala-2.12/toguru/play/PlaySupport.scala
@@ -72,8 +72,9 @@ object PlaySupport extends AbstractPlaySupport {
     * @param bodyParser the bodyParser of the controller action
     * @return
     */
-  def ToggledAction(toguruClient: PlayToguruClient,
-                    bodyParser: BodyParser[AnyContent])
-    : ActionBuilder[ToggledRequest, AnyContent] =
-    DefaultActionBuilder(bodyParser) andThen new TogglingRefiner(toguruClient)
+  def ToggledAction(
+      toguruClient: PlayToguruClient,
+      bodyParser: BodyParser[AnyContent]
+  ): ActionBuilder[ToggledRequest, AnyContent] =
+    DefaultActionBuilder(bodyParser).andThen(new TogglingRefiner(toguruClient))
 }

--- a/src/main/scala-2.12/toguru/play/TogglingRefiner.scala
+++ b/src/main/scala-2.12/toguru/play/TogglingRefiner.scala
@@ -20,9 +20,6 @@ override val activations = toguru.activationsProvider()
 class TogglingRefiner(toguruClient: PlayToguruClient)(implicit override val executionContext: ExecutionContext)
     extends ActionRefiner[Request, ToggledRequest] {
   def refine[A](request: Request[A]) = Future.successful {
-    Right(
-      new ToggledRequest[A](toguruClient.clientProvider(request),
-                            toguruClient.activationsProvider(),
-                            request))
+    Right(new ToggledRequest[A](toguruClient.clientProvider(request), toguruClient.activationsProvider(), request))
   }
 }

--- a/src/main/scala/toguru/api/ClientInfo.scala
+++ b/src/main/scala/toguru/api/ClientInfo.scala
@@ -5,9 +5,10 @@ import java.util.UUID
 import toguru.api.Toggle.ToggleId
 
 case class ClientInfo(
-             uuid: Option[UUID] = None,
-             forcedToggle: ToggleId => Option[Boolean] = (_) => None,
-             attributes: Map[String, String] = Map.empty) {
+    uuid: Option[UUID] = None,
+    forcedToggle: ToggleId => Option[Boolean] = (_) => None,
+    attributes: Map[String, String] = Map.empty
+) {
 
   /**
     * create a copy of this client info that is enriched with the given attribute name/value pair

--- a/src/main/scala/toguru/api/Condition.scala
+++ b/src/main/scala/toguru/api/Condition.scala
@@ -8,7 +8,7 @@ trait Condition {
 
 object Condition {
 
-  val On:  Condition = AlwaysOnCondition
+  val On: Condition  = AlwaysOnCondition
   val Off: Condition = AlwaysOffCondition
 
   def UuidRange(range: Range): Condition =

--- a/src/main/scala/toguru/api/Toggle.scala
+++ b/src/main/scala/toguru/api/Toggle.scala
@@ -2,7 +2,6 @@ package toguru.api
 
 import toguru.api.Toggle.ToggleId
 
-
 object Toggle {
   type ToggleId = String
 }

--- a/src/main/scala/toguru/api/Toggling.scala
+++ b/src/main/scala/toguru/api/Toggling.scala
@@ -38,8 +38,9 @@ trait Toggling {
     val toggleStates =
       activations
         .togglesFor(service)
-        .map { case (toggleId, condition) =>
-          toggleId -> client.forcedToggle(toggleId).getOrElse(condition.applies(client))
+        .map {
+          case (toggleId, condition) =>
+            toggleId -> client.forcedToggle(toggleId).getOrElse(condition.applies(client))
         }
 
     TogglesString.build(toggleStates)

--- a/src/main/scala/toguru/impl/Conditions.scala
+++ b/src/main/scala/toguru/impl/Conditions.scala
@@ -29,31 +29,32 @@ case class Attribute(name: String, values: Seq[String]) extends Condition {
   */
 case class UuidDistributionCondition(ranges: Seq[Range], f: UUID => Int) extends Condition {
 
-  ranges.foreach(r => if (r.head < 1 || r.last > 100) throw new IllegalArgumentException("Range should describe a range between 1 and 100 inclusive"))
+  ranges.foreach(r =>
+    if (r.head < 1 || r.last > 100)
+      throw new IllegalArgumentException("Range should describe a range between 1 and 100 inclusive")
+  )
 
-  override def applies(clientInfo: ClientInfo): Boolean = {
+  override def applies(clientInfo: ClientInfo): Boolean =
     clientInfo.uuid match {
       case Some(uuid) =>
         val projected = f(uuid)
-        ranges.exists(range => {
+        ranges.exists { range =>
           range.contains(projected)
-        })
+        }
       case None => false
     }
-  }
 }
 
 object UuidDistributionCondition {
 
   def apply(range: Range, f: UUID => Int = defaultUuidToIntProjection): UuidDistributionCondition = apply(Seq(range), f)
 
-  val defaultUuidToIntProjection: UUID => Int = {
-    (uuid) =>
-      val hibits = uuid.getMostSignificantBits
-      val lobits = uuid.getLeastSignificantBits
-      val barrayHi = BigInteger.valueOf(hibits).toByteArray
-      val barrayLo = BigInteger.valueOf(lobits).toByteArray
-      val comb = barrayLo ++ barrayHi
-      Math.abs(new BigInteger(comb).mod(BigInteger.valueOf(100l)).intValue()) + 1
+  val defaultUuidToIntProjection: UUID => Int = { (uuid) =>
+    val hibits   = uuid.getMostSignificantBits
+    val lobits   = uuid.getLeastSignificantBits
+    val barrayHi = BigInteger.valueOf(hibits).toByteArray
+    val barrayLo = BigInteger.valueOf(lobits).toByteArray
+    val comb     = barrayLo ++ barrayHi
+    Math.abs(new BigInteger(comb).mod(BigInteger.valueOf(100L)).intValue()) + 1
   }
 }

--- a/src/main/scala/toguru/impl/ToggleStates.scala
+++ b/src/main/scala/toguru/impl/ToggleStates.scala
@@ -14,12 +14,12 @@ object ToggleState {
     val condition: Condition = {
       val rollout = for {
         activation <- activations.headOption
-        rollout <- activation.rollout
+        rollout    <- activation.rollout
       } yield Condition.UuidRange(1 to rollout.percentage)
 
       val attributes = for {
         activation <- activations.headOption.to[Seq]
-        (k, v) <- activation.attributes
+        (k, v)     <- activation.attributes
       } yield Attribute(k, v)
 
       (attributes :+ rollout.getOrElse(Condition.Off)).to[List] match {
@@ -45,8 +45,7 @@ class ToggleStateActivations(toggleStates: ToggleStates) extends Activations {
   override def apply(): Traversable[ToggleState] = toggleStates.toggles
 
   override def togglesFor(service: String): Map[ToggleId, Condition] =
-    toggleStates
-      .toggles
+    toggleStates.toggles
       .filter { toggle =>
         toggle.tags.get("services").toVector.flatMap(_.split(",")).exists(_.trim == service) ||
         toggle.tags.get("service").exists(_.trim == service)

--- a/src/main/scala/toguru/impl/TogglesString.scala
+++ b/src/main/scala/toguru/impl/TogglesString.scala
@@ -6,27 +6,29 @@ import scala.util.Try
 
 object TogglesString {
 
-  private def lowerCaseKeys[T](m: Map[String,T]) = m.map { case (k, v) => (k.toLowerCase, v) }
+  private def lowerCaseKeys[T](m: Map[String, T]) = m.map { case (k, v) => (k.toLowerCase, v) }
 
   /**
-   * Parses the string for a forced activation of features.
-   *
-   * @param togglesString usually has a format like: feature1=true|feature2=false|feature3=true, where the feature name
+    * Parses the string for a forced activation of features.
+    *
+    * @param togglesString usually has a format like: feature1=true|feature2=false|feature3=true, where the feature name
     *                       should be case insensitive
     * @return a function that can check if a given feature should be forced to be in the given state (true| false). The
     *         feature name is case insensitive.
-   */
-  def parse(togglesString: String): ToggleId => Option[Boolean] = {
-    featureName =>
-      val map = togglesString.split('|').toList.flatMap {
-        singleFeature =>
-          singleFeature.split('=').toList match {
-            case key :: value :: Nil if Try(value.toBoolean).isSuccess => Some(key.toLowerCase -> value.toBoolean)
-            case other => None // wrong feature format. e.g. name=uh
-          }
-      }.toMap
+    */
+  def parse(togglesString: String): ToggleId => Option[Boolean] = { featureName =>
+    val map = togglesString
+      .split('|')
+      .toList
+      .flatMap { singleFeature =>
+        singleFeature.split('=').toList match {
+          case key :: value :: Nil if Try(value.toBoolean).isSuccess => Some(key.toLowerCase -> value.toBoolean)
+          case other                                                 => None // wrong feature format. e.g. name=uh
+        }
+      }
+      .toMap
 
-      lowerCaseKeys(map).get(featureName.toLowerCase)
+    lowerCaseKeys(map).get(featureName.toLowerCase)
   }
 
   /**
@@ -36,6 +38,7 @@ object TogglesString {
     * @return A feature string in the format of feature1=true|feature2=false|feature3=true. Where all feature objects in
     *         `features` are covered in the output.
     */
-  def build(toggles: Traversable[(ToggleId, Boolean)]): String = toggles.map { case (id, on) => s"$id=$on" }.mkString("|")
+  def build(toggles: Traversable[(ToggleId, Boolean)]): String =
+    toggles.map { case (id, on) => s"$id=$on" }.mkString("|")
 
 }

--- a/src/main/scala/toguru/impl/ToguruClientMetrics.scala
+++ b/src/main/scala/toguru/impl/ToguruClientMetrics.scala
@@ -49,7 +49,7 @@ trait ToguruClientMetrics {
 
   def fetchSuccess() = connectivity.heartbeat()
 
-  def fetchFailed()  = fetchFailures.inc()
+  def fetchFailed() = fetchFailures.inc()
 
   def connectError() = connectErrors.inc()
 

--- a/src/main/scala/toguru/play/AbstractPlaySupport.scala
+++ b/src/main/scala/toguru/play/AbstractPlaySupport.scala
@@ -18,8 +18,7 @@ abstract class AbstractPlaySupport {
     * @param endpointUrl    the toguru server to use, e.g. <code>http://localhost:9000</code>
     * @return
     */
-  def toguruClient(clientProvider: PlayClientProvider,
-                   endpointUrl: String): PlayToguruClient =
+  def toguruClient(clientProvider: PlayClientProvider, endpointUrl: String): PlayToguruClient =
     new ToguruClient(clientProvider, Activations.fromEndpoint(endpointUrl))
 
   /**
@@ -29,27 +28,21 @@ abstract class AbstractPlaySupport {
     * @param testActivations the acrt
     * @return
     */
-  def testToguruClient(
-      clientProvider: PlayClientProvider,
-      testActivations: Activations.Provider): PlayToguruClient =
+  def testToguruClient(clientProvider: PlayClientProvider, testActivations: Activations.Provider): PlayToguruClient =
     new ToguruClient(clientProvider, testActivations)
 
-  def uuidFromCookieValue(cookieName: String)(
-      implicit requestHeader: RequestHeader): Option[UUID] =
+  def uuidFromCookieValue(cookieName: String)(implicit requestHeader: RequestHeader): Option[UUID] =
     requestHeader.cookies
       .get(cookieName)
       .flatMap(c => Try(UUID.fromString(c.value)).toOption)
 
-  def fromCookie(name: String)(
-      implicit requestHeader: RequestHeader): Option[(String, String)] =
+  def fromCookie(name: String)(implicit requestHeader: RequestHeader): Option[(String, String)] =
     requestHeader.cookies.get(name).map(name -> _.value)
 
-  def fromHeader(name: String)(
-      implicit requestHeader: RequestHeader): Option[(String, String)] =
+  def fromHeader(name: String)(implicit requestHeader: RequestHeader): Option[(String, String)] =
     requestHeader.headers.get(name).map(name -> _)
 
-  def forcedToggle(toggleId: ToggleId)(
-      implicit requestHeader: RequestHeader): Option[Boolean] = {
+  def forcedToggle(toggleId: ToggleId)(implicit requestHeader: RequestHeader): Option[Boolean] = {
 
     def lowerCaseKeys[T](m: Map[String, T]) = m.map {
       case (k, v) => (k.toLowerCase, v)
@@ -65,23 +58,21 @@ abstract class AbstractPlaySupport {
       .orElse(requestHeader.cookies.get("toguru"))
       .flatMap(cookie => parse(cookie.value)(toggleId))
 
-    lazy val lowerCasedKeysQueryStringMap = lowerCaseKeys(
-      requestHeader.queryString)
+    lazy val lowerCasedKeysQueryStringMap = lowerCaseKeys(requestHeader.queryString)
 
     lazy val parseToggleQueryString: ToggleId => Option[Boolean] = {
       val maybeToggleString: Option[List[String]] =
         lowerCasedKeysQueryStringMap.get("toguru").map(_.toList)
 
-      toggleId =>
-        {
-          maybeToggleString
-            .map {
-              case Nil => None
-              case toggleString :: _ => // we ignore toggles defined twice by the client
-                parse(toggleString)(toggleId)
-            }
-            .getOrElse(None)
-        }
+      toggleId => {
+        maybeToggleString
+          .map {
+            case Nil => None
+            case toggleString :: _ => // we ignore toggles defined twice by the client
+              parse(toggleString)(toggleId)
+          }
+          .getOrElse(None)
+      }
     }
 
     val maybeForcedFromQueryParam = parseToggleQueryString(toggleId)

--- a/src/main/scala/toguru/play/package.scala
+++ b/src/main/scala/toguru/play/package.scala
@@ -9,8 +9,7 @@ package object play {
 
   type PlayClientProvider = ClientInfo.Provider[Request[_]]
 
-  class ToggledRequest[A](
-             val client: ClientInfo,
-             val activations: Activations,
-             request : Request[A]) extends WrappedRequest[A](request) with Toggling
+  class ToggledRequest[A](val client: ClientInfo, val activations: Activations, request: Request[A])
+      extends WrappedRequest[A](request)
+      with Toggling
 }

--- a/src/test/scala-2.11/toguru/play/ControllerHelpers.scala
+++ b/src/test/scala-2.11/toguru/play/ControllerHelpers.scala
@@ -10,13 +10,11 @@ trait ControllerHelpers { this: RequestHelpers =>
   val toggle = Toggle("toggle-1")
 
   // you will write such a class in your play app to automatically convert from Play's RequestHeader to ClientInfo
-  abstract class ToggledController(toguru: PlayToguruClient)
-      extends Controller {
+  abstract class ToggledController(toguru: PlayToguruClient) extends Controller {
     val ToggledAction = PlaySupport.ToggledAction(toguru)
   }
 
-  class MyController @Inject()(toguru: PlayToguruClient)
-      extends ToggledController(toguru) {
+  class MyController @Inject() (toguru: PlayToguruClient) extends ToggledController(toguru) {
 
     def myAction = ToggledAction { implicit request =>
       if (toggle.isOn)
@@ -26,8 +24,7 @@ trait ControllerHelpers { this: RequestHelpers =>
     }
   }
 
-  class MyControllerWithOwnTogglingInfo @Inject()(toguru: PlayToguruClient)
-      extends Controller {
+  class MyControllerWithOwnTogglingInfo @Inject() (toguru: PlayToguruClient) extends Controller {
 
     def myAction = Action { request =>
       implicit val toggling = toguru(request)
@@ -39,19 +36,16 @@ trait ControllerHelpers { this: RequestHelpers =>
     }
   }
 
-  def createToggledController(
-      provider: Activations.Provider = TestActivations()()) = {
+  def createToggledController(provider: Activations.Provider = TestActivations()()) = {
 
     val toguruClient = PlaySupport.testToguruClient(client, provider)
 
     new ToggledController(toguruClient) {}
   }
 
-  def createMyController(toguru: PlayToguruClient) = {
+  def createMyController(toguru: PlayToguruClient) =
     new MyController(toguru)
-  }
 
-  def createMyControllerWithOwnTogglingInfo(toguru: PlayToguruClient) = {
+  def createMyControllerWithOwnTogglingInfo(toguru: PlayToguruClient) =
     new MyControllerWithOwnTogglingInfo(toguru)
-  }
 }

--- a/src/test/scala-2.12/toguru/play/ControllerHelpers.scala
+++ b/src/test/scala-2.12/toguru/play/ControllerHelpers.scala
@@ -13,13 +13,12 @@ trait ControllerHelpers {
   val toggle = Toggle("toggle-1")
 
   // you will write such a class in your play app to automatically convert from Play's RequestHeader to ClientInfo
-  abstract class ToggledController(toguru: PlayToguruClient, cc: ControllerComponents)
-    extends AbstractController(cc) {
+  abstract class ToggledController(toguru: PlayToguruClient, cc: ControllerComponents) extends AbstractController(cc) {
     val ToggledAction = PlaySupport.ToggledAction(toguru, cc.parsers.defaultBodyParser)
   }
 
-  class MyController @Inject()(toguru: PlayToguruClient, cc: ControllerComponents)
-    extends ToggledController(toguru, cc) {
+  class MyController @Inject() (toguru: PlayToguruClient, cc: ControllerComponents)
+      extends ToggledController(toguru, cc) {
 
     def myAction = ToggledAction { implicit request =>
       if (toggle.isOn)
@@ -29,8 +28,8 @@ trait ControllerHelpers {
     }
   }
 
-  class MyControllerWithOwnTogglingInfo @Inject()(toguru: PlayToguruClient, cc: ControllerComponents)
-    extends AbstractController(cc) {
+  class MyControllerWithOwnTogglingInfo @Inject() (toguru: PlayToguruClient, cc: ControllerComponents)
+      extends AbstractController(cc) {
 
     def myAction = Action { request =>
       implicit val toggling = toguru(request)
@@ -42,20 +41,16 @@ trait ControllerHelpers {
     }
   }
 
-  def createToggledController(
-      provider: Activations.Provider = TestActivations()()) = {
+  def createToggledController(provider: Activations.Provider = TestActivations()()) = {
 
     val toguruClient = PlaySupport.testToguruClient(client, provider)
 
     new ToggledController(toguruClient, Helpers.stubControllerComponents()) {}
   }
 
-  def createMyController(toguru: PlayToguruClient) = {
+  def createMyController(toguru: PlayToguruClient) =
     new MyController(toguru, Helpers.stubControllerComponents())
-  }
 
-  def createMyControllerWithOwnTogglingInfo(toguru: PlayToguruClient) = {
-    new MyControllerWithOwnTogglingInfo(toguru,
-                                        Helpers.stubControllerComponents())
-  }
+  def createMyControllerWithOwnTogglingInfo(toguru: PlayToguruClient) =
+    new MyControllerWithOwnTogglingInfo(toguru, Helpers.stubControllerComponents())
 }

--- a/src/test/scala/toguru/api/ActivationsSpec.scala
+++ b/src/test/scala/toguru/api/ActivationsSpec.scala
@@ -18,7 +18,7 @@ class ActivationsSpec extends FeatureSpec with MustMatchers with MockitoSugar {
   feature("Default activations") {
     scenario("return toggle's default activation") {
       val condition = mock[Condition]
-      val toggle = Toggle("toggle-1", condition)
+      val toggle    = Toggle("toggle-1", condition)
 
       DefaultActivations.apply(toggle) mustBe condition
     }

--- a/src/test/scala/toguru/api/ConditionSpec.scala
+++ b/src/test/scala/toguru/api/ConditionSpec.scala
@@ -31,9 +31,7 @@ class ConditionSpec extends FeatureSpec with MustMatchers {
   feature("Combined Condition") {
     scenario("can be created") {
       import Condition._
-      Condition(
-        UuidRange(1 to 20),
-        Attribute("myAttribute", "one", "two", "three")) mustBe a[Condition]
+      Condition(UuidRange(1 to 20), Attribute("myAttribute", "one", "two", "three")) mustBe a[Condition]
     }
 
     scenario("when created from one condition yields the given condition") {

--- a/src/test/scala/toguru/api/ToggleSpec.scala
+++ b/src/test/scala/toguru/api/ToggleSpec.scala
@@ -9,7 +9,7 @@ class ToggleSpec extends FeatureSpec with MustMatchers {
 
   feature("Toggle creation") {
     scenario("default condition is false") {
-      val toggle1 = Toggle("toggle-1")
+      val toggle1             = Toggle("toggle-1")
       implicit val toggleInfo = emptyToggleInfo
 
       toggle1.isOn mustBe false
@@ -17,7 +17,7 @@ class ToggleSpec extends FeatureSpec with MustMatchers {
     }
 
     scenario("default condition is respected") {
-      val toggle1 = Toggle("toggle-1", default = Condition.On)
+      val toggle1             = Toggle("toggle-1", default = Condition.On)
       implicit val toggleInfo = emptyToggleInfo
 
       toggle1.isOn mustBe true

--- a/src/test/scala/toguru/api/TogglingSpec.scala
+++ b/src/test/scala/toguru/api/TogglingSpec.scala
@@ -9,7 +9,7 @@ class TogglingSpec extends FeatureSpec with MustMatchers {
 
   feature("Can change toggle state") {
     scenario("toggle state in toggle info is applied") {
-      val toggle1 = Toggle("toggle-1", default = Condition.Off)
+      val toggle1    = Toggle("toggle-1", default = Condition.Off)
       val activation = new TestActivations.Impl(toggle1 -> Condition.On)()
 
       implicit val info = TogglingInfo(ClientInfo(), activation)
@@ -18,7 +18,7 @@ class TogglingSpec extends FeatureSpec with MustMatchers {
     }
 
     scenario("default toggle state is applied") {
-      val toggle1 = Toggle("toggle-1", default = Condition.On)
+      val toggle1    = Toggle("toggle-1", default = Condition.On)
       val activation = new TestActivations.Impl()()
 
       implicit val info = TogglingInfo(ClientInfo(), activation)
@@ -27,9 +27,9 @@ class TogglingSpec extends FeatureSpec with MustMatchers {
     }
 
     scenario("toggle state can be forced by client info") {
-      val toggle1 = Toggle("toggle-1", default = Condition.Off)
+      val toggle1    = Toggle("toggle-1", default = Condition.Off)
       val activation = new TestActivations.Impl(toggle1 -> Condition.Off)()
-      val info = ClientInfo(forcedToggle = ClientInfoHelper.forceToggleTo("toggle-1", enabled = true))
+      val info       = ClientInfo(forcedToggle = ClientInfoHelper.forceToggleTo("toggle-1", enabled = true))
 
       implicit val toggleInfo = TogglingInfo(info, activation)
 
@@ -37,9 +37,9 @@ class TogglingSpec extends FeatureSpec with MustMatchers {
     }
 
     scenario("toggle state falls back to false if client uuid is None") {
-      val toggle1 = Toggle("toggle-1", default = Condition.On)
+      val toggle1    = Toggle("toggle-1", default = Condition.On)
       val activation = new TestActivations.Impl(toggle1 -> Condition.UuidRange(1 to 100))()
-      val info = ClientInfo(uuid = None)
+      val info       = ClientInfo(uuid = None)
 
       implicit val toggleInfo = TogglingInfo(info, activation)
 
@@ -51,28 +51,28 @@ class TogglingSpec extends FeatureSpec with MustMatchers {
     import toguru.implicits.toggle._
 
     scenario("produces 'on' when toggle state is 'off' but the client overrides it to be 'on'") {
-      val toggle = Toggle("feature1")
-      val activations = TestActivations(toggle -> Condition.Off)(toggle -> "service1")()
-      val clientInfo = ClientInfo(None, forceToggleTo("feature1", enabled = true))
+      val toggle              = Toggle("feature1")
+      val activations         = TestActivations(toggle -> Condition.Off)(toggle -> "service1")()
+      val clientInfo          = ClientInfo(None, forceToggleTo("feature1", enabled = true))
       implicit val toggleInfo = TogglingInfo(clientInfo, activations)
 
       toggleInfo().buildString mustBe ("feature1=true")
     }
 
     scenario("produces 'off' when toggle state is 'on' but the client overrides it to be 'off'") {
-      val toggle = Toggle("feature1")
-      val activations = TestActivations(toggle -> Condition.On)(toggle -> "service1")()
+      val toggle                          = Toggle("feature1")
+      val activations                     = TestActivations(toggle -> Condition.On)(toggle -> "service1")()
       implicit val clientInfo: ClientInfo = ClientInfo(None, forceToggleTo("feature1", enabled = false))
-      implicit val toggleInfo = TogglingInfo(clientInfo, activations)
+      implicit val toggleInfo             = TogglingInfo(clientInfo, activations)
 
       toggleInfo().buildString mustBe ("feature1=false")
     }
 
     scenario("produces 'on' when toggle state is 'on'") {
-      val toggle = Toggle("feature1")
-      val activations = TestActivations(toggle -> Condition.On)(toggle -> "service1")()
+      val toggle                          = Toggle("feature1")
+      val activations                     = TestActivations(toggle -> Condition.On)(toggle -> "service1")()
       implicit val clientInfo: ClientInfo = ClientInfo()
-      implicit val toggleInfo = TogglingInfo(clientInfo, activations)
+      implicit val toggleInfo             = TogglingInfo(clientInfo, activations)
 
       toggleInfo().buildString mustBe ("feature1=true")
     }

--- a/src/test/scala/toguru/api/ToguruClientSpec.scala
+++ b/src/test/scala/toguru/api/ToguruClientSpec.scala
@@ -13,12 +13,14 @@ class ToguruClientSpec extends FeatureSpec with MustMatchers with MockitoSugar {
   def activationProvider(activations: Activations = DefaultActivations, health: Boolean): Activations.Provider =
     new Provider {
       def healthy() = health
-      def apply() = activations
+      def apply()   = activations
     }
 
-  def toguruClient(clientProvider: ClientInfo.Provider[String] = mockClientProvider, activations: Activations.Provider) =
+  def toguruClient(
+      clientProvider: ClientInfo.Provider[String] = mockClientProvider,
+      activations: Activations.Provider
+  ) =
     new ToguruClient(clientProvider, activations)
-
 
   feature("health check") {
     scenario("activations provider is healthy") {
@@ -36,11 +38,12 @@ class ToguruClientSpec extends FeatureSpec with MustMatchers with MockitoSugar {
 
   feature("client info provider") {
     scenario("client info requested") {
-      val myActivations = mock[Activations]
+      val myActivations      = mock[Activations]
       val myInfo: ClientInfo = ClientInfo().withAttribute("user", "me")
       val client = toguruClient(
         clientProvider = _ => myInfo,
-        activations = activationProvider(health = true, activations = myActivations))
+        activations = activationProvider(health = true, activations = myActivations)
+      )
 
       val toggling = client.apply("client")
 

--- a/src/test/scala/toguru/helpers/ClientInfoHelper.scala
+++ b/src/test/scala/toguru/helpers/ClientInfoHelper.scala
@@ -11,6 +11,6 @@ object ClientInfoHelper {
     * @return A function that forces `featureName` to be a particular state
     */
   def forceToggleTo(toggleId: ToggleId, enabled: Boolean): (ToggleId => Option[Boolean]) = { id =>
-    if(id == toggleId) Some(enabled) else None
+    if (id == toggleId) Some(enabled) else None
   }
 }

--- a/src/test/scala/toguru/impl/ToggleStateSpec.scala
+++ b/src/test/scala/toguru/impl/ToggleStateSpec.scala
@@ -14,15 +14,22 @@ class ToggleStateSpec extends WordSpec with MustMatchers with MockitoSugar {
   val toggles = List(
     ToggleState("toggle1", Map("services" -> "toguru"), activation(rollout(30))),
     ToggleState("toggle-2", Map.empty[String, String], activation(rollout(100))),
-    ToggleState("toggle-4", Map.empty[String, String], activation(attrs = Map("culture" -> Seq("DE", "de-DE"), "version" -> Seq("1", "2")))),
-    ToggleState("toggle-5", Map.empty[String, String], activation(rollout(30), attrs = Map("culture" -> Seq("DE", "de-DE"), "version" -> Seq("1", "2")))),
-    ToggleState("toggle6", Map("services" -> "my-service,another-service"), activation(rollout(15))),
-    ToggleState("toggle7", Map("services" -> "my-service "), activation(rollout(1))),
-    ToggleState("toggle8", Map("service" -> " my-service"), activation(rollout(100))),
-    ToggleState("toggle9", Map("services" -> "another-service,yet-another-service,my-service"), activation()),
+    ToggleState(
+      "toggle-4",
+      Map.empty[String, String],
+      activation(attrs = Map("culture" -> Seq("DE", "de-DE"), "version" -> Seq("1", "2")))
+    ),
+    ToggleState(
+      "toggle-5",
+      Map.empty[String, String],
+      activation(rollout(30), attrs = Map("culture" -> Seq("DE", "de-DE"), "version" -> Seq("1", "2")))
+    ),
+    ToggleState("toggle6", Map("services"  -> "my-service,another-service"), activation(rollout(15))),
+    ToggleState("toggle7", Map("services"  -> "my-service "), activation(rollout(1))),
+    ToggleState("toggle8", Map("service"   -> " my-service"), activation(rollout(100))),
+    ToggleState("toggle9", Map("services"  -> "another-service,yet-another-service,my-service"), activation()),
     ToggleState("toggle10", Map("services" -> "another-service, my-service, yet-another-service"), activation())
   )
-
 
   "ToggleState.apply" should {
 
@@ -39,16 +46,21 @@ class ToggleStateSpec extends WordSpec with MustMatchers with MockitoSugar {
     "Adds AlwayOffCondition if only attribute contitions are given" in {
       val condition = toggles(2).condition
 
-      condition mustBe All(Set(AlwaysOffCondition, Attribute("culture", Seq("DE", "de-DE")), Attribute("version", Seq("1", "2"))))
+      condition mustBe All(
+        Set(AlwaysOffCondition, Attribute("culture", Seq("DE", "de-DE")), Attribute("version", Seq("1", "2")))
+      )
     }
 
     "transform combinations of rollout and attributes to conditions" in {
       val condition = toggles(3).condition
 
-      condition mustBe All(Set(
-        UuidDistributionCondition(List(1 to 30), UuidDistributionCondition.defaultUuidToIntProjection),
-        Attribute("culture", Seq("DE", "de-DE")),
-        Attribute("version", Seq("1", "2"))))
+      condition mustBe All(
+        Set(
+          UuidDistributionCondition(List(1 to 30), UuidDistributionCondition.defaultUuidToIntProjection),
+          Attribute("culture", Seq("DE", "de-DE")),
+          Attribute("version", Seq("1", "2"))
+        )
+      )
     }
   }
 
@@ -80,7 +92,7 @@ class ToggleStateSpec extends WordSpec with MustMatchers with MockitoSugar {
 
     "return toggle default conditions if toggle is unknown" in {
       val condition = mock[Condition]
-      val toggle = Toggle("toggle-3", condition)
+      val toggle    = Toggle("toggle-3", condition)
 
       activations.apply(toggle) mustBe condition
     }

--- a/src/test/scala/toguru/impl/TogglesStringSpec.scala
+++ b/src/test/scala/toguru/impl/TogglesStringSpec.scala
@@ -9,7 +9,7 @@ class TogglesStringSpec extends WordSpec with MustMatchers {
   "Parsing of forced features string" should {
 
     val forcedTogglesString = "feature1=true|feature2=false|feature3=true"
-    val forcedToggles = TogglesString.parse(forcedTogglesString)
+    val forcedToggles       = TogglesString.parse(forcedTogglesString)
 
     "Existing features are correctly forced" in {
       forcedToggles("feature1").value mustBe true
@@ -27,7 +27,7 @@ class TogglesStringSpec extends WordSpec with MustMatchers {
 
     "Illegal feature spec returns None for feature specified wrongly" in {
       val forcedFeaturesString = "feature1=thisiswrong|feature2=false|feature3=true"
-      val forcedFeatures = TogglesString.parse(forcedFeaturesString)
+      val forcedFeatures       = TogglesString.parse(forcedFeaturesString)
 
       forcedFeatures("feature1") mustBe None
       forcedFeatures("feature3").value mustBe true
@@ -43,21 +43,21 @@ class TogglesStringSpec extends WordSpec with MustMatchers {
 
     "returns the correct feature when it is enforced to be true" in {
       implicit val clientInfo: ClientInfo = ClientInfo()
-      val toggleStates = Map("feature1" -> true)
+      val toggleStates                    = Map("feature1" -> true)
 
       TogglesString.build(toggleStates) mustBe "feature1=true"
     }
 
     "returns the disabled feature when it is enforced to be false" in {
       implicit val clientInfo: ClientInfo = ClientInfo()
-      val toggleStates = Map("feature1" -> false)
+      val toggleStates                    = Map("feature1" -> false)
 
       TogglesString.build(toggleStates) mustBe "feature1=false"
     }
 
     "returns multiple features separated by a pipe" in {
       implicit val clientInfo: ClientInfo = ClientInfo()
-      val toggleStates = Map("feature1" -> false, "feature2" -> true)
+      val toggleStates                    = Map("feature1" -> false, "feature2" -> true)
 
       TogglesString.build(toggleStates) mustBe "feature1=false|feature2=true"
     }

--- a/src/test/scala/toguru/impl/UuidDistributionConditionSpec.scala
+++ b/src/test/scala/toguru/impl/UuidDistributionConditionSpec.scala
@@ -25,11 +25,10 @@ class UuidDistributionConditionSpec extends WordSpec with MustMatchers with Tabl
 
   "Valid UUIDs" should {
     "be projected within max range" in {
-      1 to 1000 foreach {
-        _ =>
-          val uuid = UUID.randomUUID()
-          val info = ClientInfo(uuid = Some(uuid))
-          UuidDistributionCondition.apply(1 to 100).applies(info) mustBe true
+      (1 to 1000).foreach { _ =>
+        val uuid = UUID.randomUUID()
+        val info = ClientInfo(uuid = Some(uuid))
+        UuidDistributionCondition.apply(1 to 100).applies(info) mustBe true
       }
     }
   }

--- a/src/test/scala/toguru/play/PlaySupportSpec.scala
+++ b/src/test/scala/toguru/play/PlaySupportSpec.scala
@@ -28,8 +28,8 @@ class PlaySupportSpec extends WordSpec with MustMatchers with RequestHelpers wit
   "ToggledAction helper" should {
     "provide request with toggling information" in {
       implicit val timeout = Timeout(2.seconds)
-      val toguru = PlaySupport.testToguruClient(client, TestActivations(toggle -> Condition.On)())
-      val controller = createMyController(toguru)
+      val toguru           = PlaySupport.testToguruClient(client, TestActivations(toggle -> Condition.On)())
+      val controller       = createMyController(toguru)
 
       val request = FakeRequest(HttpVerbs.GET, "/")
 
@@ -42,8 +42,8 @@ class PlaySupportSpec extends WordSpec with MustMatchers with RequestHelpers wit
   "Direct toggling info" should {
     "provide toggling information" in {
       implicit val timeout = Timeout(2.seconds)
-      val toguru = PlaySupport.testToguruClient(client, TestActivations(toggle -> Condition.On)())
-      val controller = createMyControllerWithOwnTogglingInfo(toguru)
+      val toguru           = PlaySupport.testToguruClient(client, TestActivations(toggle -> Condition.On)())
+      val controller       = createMyControllerWithOwnTogglingInfo(toguru)
 
       val request = FakeRequest(HttpVerbs.GET, "/")
 
@@ -62,7 +62,9 @@ class PlaySupportSpec extends WordSpec with MustMatchers with RequestHelpers wit
 
     "extract of user agent from user agent header" in {
       val clientInfo = client(request)
-      clientInfo.attributes.get(UserAgent).value mustBe "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
+      clientInfo.attributes
+        .get(UserAgent)
+        .value mustBe "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
     }
 
     "extract of uuid from GUID or visitor cookie" in {

--- a/src/test/scala/toguru/play/RequestHelpers.scala
+++ b/src/test/scala/toguru/play/RequestHelpers.scala
@@ -17,28 +17,31 @@ trait RequestHelpers {
 
   val fakeHeaders = FakeHeaders(
     Seq(
-      UserAgent -> "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36",
+      UserAgent  -> "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36",
       "X-toguru" -> "feature1-Forced-By-Header=true|feature2-Forced-By-Header=true",
       HeaderNames.COOKIE ->
-        Cookies.encodeCookieHeader(Seq(
-          Cookie("culture", "de-DE"),
-          Cookie("myVisitor", "a5f409eb-2fdd-4499-b65b-b22bd7e51aa2"),
-          Cookie(
-            "toguru",
-            "feature1-Forced-By-Cookie=true|feature2-Forced-By-Cookie=true")
-        ))
-    ))
+        Cookies.encodeCookieHeader(
+          Seq(
+            Cookie("culture", "de-DE"),
+            Cookie("myVisitor", "a5f409eb-2fdd-4499-b65b-b22bd7e51aa2"),
+            Cookie("toguru", "feature1-Forced-By-Cookie=true|feature2-Forced-By-Cookie=true")
+          )
+        )
+    )
+  )
 
   val request = FakeRequest.apply(
     "GET",
     "http://priceestimation.autoscout24.de?toguru=feature-forced-by-query-param%3Dtrue",
     fakeHeaders,
-    "body")
+    "body"
+  )
   val requestWithToggleIdUpppercased = FakeRequest.apply(
     "GET",
     "http://priceestimation.autoscout24.de?toguru=feature-FORCED-by-query-param%3Dtrue",
     fakeHeaders,
-    "body")
+    "body"
+  )
   val requestWithTwoTogglesInQueryString = FakeRequest.apply(
     "GET",
     "http://priceestimation.autoscout24.de?toguru=feature1-forced-by-query-param%3Dtrue%7Cfeature2-forced-by-query-param%3Dfalse",

--- a/src/test/scala/toguru/test/TestActivationsSpec.scala
+++ b/src/test/scala/toguru/test/TestActivationsSpec.scala
@@ -13,17 +13,17 @@ class TestActivationsSpec extends WordSpec with MustMatchers {
 
   "activations" should {
     "return the activations given in the constructor" in {
-      val toggle = Toggle("test-toggle")
+      val toggle              = Toggle("test-toggle")
       val activationsProvider = TestActivations(toggle -> Condition.On)()
-      val activations = activationsProvider()
+      val activations         = activationsProvider()
 
       activations(toggle) mustBe Condition.On
     }
 
     "return the default activations if no activation was given" in {
-      val toggle = Toggle("test-toggle", default = Condition.On)
+      val toggle              = Toggle("test-toggle", default = Condition.On)
       val activationsProvider = TestActivations()()
-      val activations = activationsProvider()
+      val activations         = activationsProvider()
 
       activations(toggle) mustBe Condition.On
     }
@@ -31,9 +31,9 @@ class TestActivationsSpec extends WordSpec with MustMatchers {
 
   "serviceFor" should {
     "return the toggles as given in the test" in {
-      val toggle = Toggle("test-toggle")
+      val toggle        = Toggle("test-toggle")
       val anotherToggle = Toggle("another-toggle")
-      val activations = TestActivations(toggle -> Condition.On, anotherToggle -> Condition.Off)(toggle -> "my-service")
+      val activations   = TestActivations(toggle -> Condition.On, anotherToggle -> Condition.Off)(toggle -> "my-service")
 
       val toggles = activations().togglesFor("my-service")
 


### PR DESCRIPTION
Enforce a consistent code style by using `scalafmt` and checking formatting on TravisCI.