### PR TITLE
Update and clean up dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,10 +36,8 @@ lazy val core = projectMatrix
     libraryDependencies ++= Seq(
       "org.scalaj"                 %% "scalaj-http"                 % "2.3.0",
       "com.typesafe.scala-logging" %% "scala-logging"               % "3.5.0",
-      "commons-io"                 % "commons-io"                   % "2.4",
       "io.dropwizard.metrics"      % "metrics-core"                 % "3.1.0",
       "org.komamitsu"              % "phi-accural-failure-detector" % "0.0.3",
-      "org.scalactic"              %% "scalactic"                   % "3.0.3",
       "com.hootsuite"              %% "scala-circuit-breaker"       % "1.0.2",
       "org.mockito"                % "mockito-core"                 % "2.0.8-beta" % "test",
       "org.scalatest"              %% "scalatest"                   % "3.0.3" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -36,9 +36,9 @@ lazy val core = projectMatrix
     libraryDependencies ++= Seq(
       "org.scalaj"                 %% "scalaj-http"                 % "2.3.0",
       "com.typesafe.scala-logging" %% "scala-logging"               % "3.5.0",
-      "io.dropwizard.metrics"      % "metrics-core"                 % "3.1.0",
-      "org.komamitsu"              % "phi-accural-failure-detector" % "0.0.3",
-      "com.hootsuite"              %% "scala-circuit-breaker"       % "1.0.2",
+      "io.dropwizard.metrics"      % "metrics-core"                 % "3.1.5",
+      "org.komamitsu"              % "phi-accural-failure-detector" % "0.0.5",
+      "com.hootsuite"              %% "scala-circuit-breaker"       % "1.0.5",
       "org.mockito"                % "mockito-core"                 % "2.0.8-beta" % "test",
       "org.scalatest"              %% "scalatest"                   % "3.0.3" % "test",
       "org.http4s"                 %% "http4s-dsl"                  % "0.17.0-M3" % "test",
@@ -49,12 +49,12 @@ lazy val core = projectMatrix
     scalaVersions = Seq("2.12.10", "2.11.12"),
     settings = Seq(
       libraryDependencies ++= {
-        val playVersion = scalaBinaryVersion.value match {
-          case "2.12" => "2.6.1"
-          case "2.11" => "2.5.4"
+        val (playVersion, playJsonVersion) = scalaBinaryVersion.value match {
+          case "2.12" => ("2.6.25", "2.6.14")
+          case "2.11" => ("2.5.19", "2.5.19")
         }
         Seq(
-          "com.typesafe.play" %% "play-json" % playVersion,
+          "com.typesafe.play" %% "play-json" % playJsonVersion,
           "com.typesafe.play" %% "play"      % playVersion % "optional",
           "com.typesafe.play" %% "play-test" % playVersion % "optional"
         )

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val core = projectMatrix
     )
   )
   .jvmPlatform(
-    scalaVersions = Seq("2.12.3", "2.11.8"),
+    scalaVersions = Seq("2.12.10", "2.11.12"),
     settings = Seq(
       libraryDependencies ++= {
         val playVersion = scalaBinaryVersion.value match {

--- a/build.sbt
+++ b/build.sbt
@@ -39,8 +39,8 @@ lazy val core = projectMatrix
       "io.dropwizard.metrics"      % "metrics-core"                 % "3.1.5",
       "org.komamitsu"              % "phi-accural-failure-detector" % "0.0.5",
       "com.hootsuite"              %% "scala-circuit-breaker"       % "1.0.5",
-      "org.mockito"                % "mockito-core"                 % "2.0.8-beta" % "test",
-      "org.scalatest"              %% "scalatest"                   % "3.0.3" % "test",
+      "org.mockito"                %% "mockito-scala-scalatest"     % "1.10.0" % "test",
+      "org.scalatest"              %% "scalatest"                   % "3.1.0" % "test",
       "org.http4s"                 %% "http4s-dsl"                  % "0.17.0-M3" % "test",
       "org.http4s"                 %% "http4s-blaze-server"         % "0.17.0-M3" % "test"
     )
@@ -56,7 +56,7 @@ lazy val core = projectMatrix
         Seq(
           "com.typesafe.play" %% "play-json" % playJsonVersion,
           "com.typesafe.play" %% "play"      % playVersion % "optional",
-          "com.typesafe.play" %% "play-test" % playVersion % "optional"
+          "com.typesafe.play" %% "play-test" % playVersion % "test"
         )
       }
     )

--- a/core/src/test/scala/toguru/api/ActivationsSpec.scala
+++ b/core/src/test/scala/toguru/api/ActivationsSpec.scala
@@ -1,13 +1,14 @@
 package toguru.api
 
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FeatureSpec, MustMatchers}
+import org.mockito.scalatest.IdiomaticMockito
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.must.Matchers
 import toguru.impl.RemoteActivationsProvider
 
-class ActivationsSpec extends FeatureSpec with MustMatchers with MockitoSugar {
+class ActivationsSpec extends AnyFeatureSpec with Matchers with IdiomaticMockito {
 
-  feature("Remote activations provider") {
-    scenario("can be created") {
+  Feature("Remote activations provider") {
+    Scenario("can be created") {
       val provider = Activations.fromEndpoint("http://localhost:9000/togglestates")
 
       provider mustBe a[RemoteActivationsProvider]
@@ -15,19 +16,19 @@ class ActivationsSpec extends FeatureSpec with MustMatchers with MockitoSugar {
     }
   }
 
-  feature("Default activations") {
-    scenario("return toggle's default activation") {
+  Feature("Default activations") {
+    Scenario("return toggle's default activation") {
       val condition = mock[Condition]
       val toggle    = Toggle("toggle-1", condition)
 
       DefaultActivations.apply(toggle) mustBe condition
     }
 
-    scenario("return empty service toggles") {
+    Scenario("return empty service toggles") {
       DefaultActivations.togglesFor("my-service") mustBe Map.empty
     }
 
-    scenario("return None for sequenceNo") {
+    Scenario("return None for sequenceNo") {
       DefaultActivations.stateSequenceNo mustBe None
     }
   }

--- a/core/src/test/scala/toguru/api/ConditionSpec.scala
+++ b/core/src/test/scala/toguru/api/ConditionSpec.scala
@@ -1,44 +1,45 @@
 package toguru.api
 
-import org.scalatest.{FeatureSpec, _}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.must.Matchers
 
-class ConditionSpec extends FeatureSpec with MustMatchers {
+class ConditionSpec extends AnyFeatureSpec with Matchers {
 
-  feature("Off Condition") {
-    scenario("can be created by API") {
+  Feature("Off Condition") {
+    Scenario("can be created by API") {
       Condition.Off mustBe a[Condition]
     }
   }
 
-  feature("On Condition") {
-    scenario("can be created") {
+  Feature("On Condition") {
+    Scenario("can be created") {
       Condition.On mustBe a[Condition]
     }
   }
 
-  feature("Rollout Range Condition") {
-    scenario("can be created") {
+  Feature("Rollout Range Condition") {
+    Scenario("can be created") {
       Condition.UuidRange(1 to 20) mustBe a[Condition]
     }
   }
 
-  feature("Attribute Condition") {
-    scenario("can be created") {
+  Feature("Attribute Condition") {
+    Scenario("can be created") {
       Condition.Attribute("myAttribute", "one", "two", "three") mustBe a[Condition]
     }
   }
 
-  feature("Combined Condition") {
-    scenario("can be created") {
+  Feature("Combined Condition") {
+    Scenario("can be created") {
       import Condition._
       Condition(UuidRange(1 to 20), Attribute("myAttribute", "one", "two", "three")) mustBe a[Condition]
     }
 
-    scenario("when created from one condition yields the given condition") {
+    Scenario("when created from one condition yields the given condition") {
       Condition(Condition.Off) mustBe Condition.Off
     }
 
-    scenario("when created from empty conditions yields Condition 'On'") {
+    Scenario("when created from empty conditions yields Condition 'On'") {
       Condition() mustBe Condition.On
     }
   }

--- a/core/src/test/scala/toguru/api/ToggleSpec.scala
+++ b/core/src/test/scala/toguru/api/ToggleSpec.scala
@@ -1,14 +1,15 @@
 package toguru.api
 
-import org.scalatest.{FeatureSpec, MustMatchers}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.must.Matchers
 import toguru.test.TestActivations
 
-class ToggleSpec extends FeatureSpec with MustMatchers {
+class ToggleSpec extends AnyFeatureSpec with Matchers {
 
   val emptyToggleInfo = TogglingInfo(ClientInfo(), new TestActivations.Impl()())
 
-  feature("Toggle creation") {
-    scenario("default condition is false") {
+  Feature("Toggle creation") {
+    Scenario("default condition is false") {
       val toggle1             = Toggle("toggle-1")
       implicit val toggleInfo = emptyToggleInfo
 
@@ -16,7 +17,7 @@ class ToggleSpec extends FeatureSpec with MustMatchers {
       toggle1.isOff mustBe true
     }
 
-    scenario("default condition is respected") {
+    Scenario("default condition is respected") {
       val toggle1             = Toggle("toggle-1", default = Condition.On)
       implicit val toggleInfo = emptyToggleInfo
 

--- a/core/src/test/scala/toguru/api/TogglingSpec.scala
+++ b/core/src/test/scala/toguru/api/TogglingSpec.scala
@@ -1,14 +1,15 @@
 package toguru.api
 
-import org.scalatest.{FeatureSpec, _}
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.must.Matchers
 import toguru.helpers.ClientInfoHelper
 import toguru.helpers.ClientInfoHelper._
 import toguru.test.TestActivations
 
-class TogglingSpec extends FeatureSpec with MustMatchers {
+class TogglingSpec extends AnyFeatureSpec with Matchers {
 
-  feature("Can change toggle state") {
-    scenario("toggle state in toggle info is applied") {
+  Feature("Can change toggle state") {
+    Scenario("toggle state in toggle info is applied") {
       val toggle1    = Toggle("toggle-1", default = Condition.Off)
       val activation = new TestActivations.Impl(toggle1 -> Condition.On)()
 
@@ -17,7 +18,7 @@ class TogglingSpec extends FeatureSpec with MustMatchers {
       toggle1.isOn mustBe true
     }
 
-    scenario("default toggle state is applied") {
+    Scenario("default toggle state is applied") {
       val toggle1    = Toggle("toggle-1", default = Condition.On)
       val activation = new TestActivations.Impl()()
 
@@ -26,7 +27,7 @@ class TogglingSpec extends FeatureSpec with MustMatchers {
       toggle1.isOn mustBe true
     }
 
-    scenario("toggle state can be forced by client info") {
+    Scenario("toggle state can be forced by client info") {
       val toggle1    = Toggle("toggle-1", default = Condition.Off)
       val activation = new TestActivations.Impl(toggle1 -> Condition.Off)()
       val info       = ClientInfo(forcedToggle = ClientInfoHelper.forceToggleTo("toggle-1", enabled = true))
@@ -36,7 +37,7 @@ class TogglingSpec extends FeatureSpec with MustMatchers {
       toggle1.isOn mustBe true
     }
 
-    scenario("toggle state falls back to false if client uuid is None") {
+    Scenario("toggle state falls back to false if client uuid is None") {
       val toggle1    = Toggle("toggle-1", default = Condition.On)
       val activation = new TestActivations.Impl(toggle1 -> Condition.UuidRange(1 to 100))()
       val info       = ClientInfo(uuid = None)
@@ -47,10 +48,10 @@ class TogglingSpec extends FeatureSpec with MustMatchers {
     }
   }
 
-  feature("Can build toggle strings") {
+  Feature("Can build toggle strings") {
     import toguru.implicits.toggle._
 
-    scenario("produces 'on' when toggle state is 'off' but the client overrides it to be 'on'") {
+    Scenario("produces 'on' when toggle state is 'off' but the client overrides it to be 'on'") {
       val toggle              = Toggle("feature1")
       val activations         = TestActivations(toggle -> Condition.Off)(toggle -> "service1")()
       val clientInfo          = ClientInfo(None, forceToggleTo("feature1", enabled = true))
@@ -59,7 +60,7 @@ class TogglingSpec extends FeatureSpec with MustMatchers {
       toggleInfo().buildString mustBe ("feature1=true")
     }
 
-    scenario("produces 'off' when toggle state is 'on' but the client overrides it to be 'off'") {
+    Scenario("produces 'off' when toggle state is 'on' but the client overrides it to be 'off'") {
       val toggle                          = Toggle("feature1")
       val activations                     = TestActivations(toggle -> Condition.On)(toggle -> "service1")()
       implicit val clientInfo: ClientInfo = ClientInfo(None, forceToggleTo("feature1", enabled = false))
@@ -68,7 +69,7 @@ class TogglingSpec extends FeatureSpec with MustMatchers {
       toggleInfo().buildString mustBe ("feature1=false")
     }
 
-    scenario("produces 'on' when toggle state is 'on'") {
+    Scenario("produces 'on' when toggle state is 'on'") {
       val toggle                          = Toggle("feature1")
       val activations                     = TestActivations(toggle -> Condition.On)(toggle -> "service1")()
       implicit val clientInfo: ClientInfo = ClientInfo()

--- a/core/src/test/scala/toguru/api/ToguruClientSpec.scala
+++ b/core/src/test/scala/toguru/api/ToguruClientSpec.scala
@@ -1,10 +1,11 @@
 package toguru.api
 
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{FeatureSpec, _}
+import org.mockito.scalatest.IdiomaticMockito
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.must.Matchers
 import toguru.api.Activations.Provider
 
-class ToguruClientSpec extends FeatureSpec with MustMatchers with MockitoSugar {
+class ToguruClientSpec extends AnyFeatureSpec with Matchers with IdiomaticMockito {
 
   val mockClientInfo = ClientInfo()
 
@@ -22,22 +23,22 @@ class ToguruClientSpec extends FeatureSpec with MustMatchers with MockitoSugar {
   ) =
     new ToguruClient(clientProvider, activations)
 
-  feature("health check") {
-    scenario("activations provider is healthy") {
+  Feature("health check") {
+    Scenario("activations provider is healthy") {
       val client = toguruClient(activations = activationProvider(health = true))
 
       client.healthy() mustBe true
     }
 
-    scenario("activations provider is unhealthy") {
+    Scenario("activations provider is unhealthy") {
       val client = toguruClient(activations = activationProvider(health = false))
 
       client.healthy() mustBe false
     }
   }
 
-  feature("client info provider") {
-    scenario("client info requested") {
+  Feature("client info provider") {
+    Scenario("client info requested") {
       val myActivations      = mock[Activations]
       val myInfo: ClientInfo = ClientInfo().withAttribute("user", "me")
       val client = toguruClient(

--- a/core/src/test/scala/toguru/impl/ConditionsSpec.scala
+++ b/core/src/test/scala/toguru/impl/ConditionsSpec.scala
@@ -2,10 +2,11 @@ package toguru.impl
 
 import java.util.UUID
 
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import toguru.api.ClientInfo
 
-class ConditionsSpec extends WordSpec with MustMatchers {
+class ConditionsSpec extends AnyWordSpec with Matchers {
 
   "Attribute conditions" should {
     "apply correctly to de-DE culture" in {

--- a/core/src/test/scala/toguru/impl/RemoteActivationsProviderSpec.scala
+++ b/core/src/test/scala/toguru/impl/RemoteActivationsProviderSpec.scala
@@ -9,14 +9,16 @@ import org.http4s.dsl._
 import org.http4s.headers._
 import org.http4s.server.blaze.BlazeBuilder
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{MustMatchers, OptionValues, WordSpec}
+import org.mockito.scalatest.IdiomaticMockito
+import org.scalatest.OptionValues
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import toguru.api.{Condition, DefaultActivations, Toggle}
 import toguru.impl.RemoteActivationsProvider.{PollResponse, TogglePoller}
 
 import scala.concurrent.duration.{FiniteDuration, _}
 
-class RemoteActivationsProviderSpec extends WordSpec with OptionValues with MustMatchers with MockitoSugar {
+class RemoteActivationsProviderSpec extends AnyWordSpec with OptionValues with Matchers with IdiomaticMockito {
 
   val toggleOne = Toggle("toggle-one")
   val toggleTwo = Toggle("toggle-two")

--- a/core/src/test/scala/toguru/impl/ToggleStateSpec.scala
+++ b/core/src/test/scala/toguru/impl/ToggleStateSpec.scala
@@ -1,10 +1,11 @@
 package toguru.impl
 
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{MustMatchers, WordSpec}
+import org.mockito.scalatest.IdiomaticMockito
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import toguru.api.{Condition, Toggle}
 
-class ToggleStateSpec extends WordSpec with MustMatchers with MockitoSugar {
+class ToggleStateSpec extends AnyWordSpec with Matchers with IdiomaticMockito {
 
   def activation(rollout: Option[Rollout] = None, attrs: Map[String, Seq[String]] = Map.empty) =
     Seq(ToggleActivation(rollout, attrs))

--- a/core/src/test/scala/toguru/impl/TogglesStringSpec.scala
+++ b/core/src/test/scala/toguru/impl/TogglesStringSpec.scala
@@ -1,10 +1,11 @@
 package toguru.impl
 
 import org.scalatest.OptionValues._
-import org.scalatest._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import toguru.api._
 
-class TogglesStringSpec extends WordSpec with MustMatchers {
+class TogglesStringSpec extends AnyWordSpec with Matchers {
 
   "Parsing of forced features string" should {
 

--- a/core/src/test/scala/toguru/impl/UuidDistributionConditionSpec.scala
+++ b/core/src/test/scala/toguru/impl/UuidDistributionConditionSpec.scala
@@ -2,11 +2,12 @@ package toguru.impl
 
 import java.util.UUID
 
+import org.scalatest.matchers.must.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
 import toguru.api.ClientInfo
 
-class UuidDistributionConditionSpec extends WordSpec with MustMatchers with TableDrivenPropertyChecks {
+class UuidDistributionConditionSpec extends AnyWordSpec with Matchers with TableDrivenPropertyChecks {
 
   "Invalid ranges" should {
     "Lower boundary is too low" in {

--- a/core/src/test/scala/toguru/play/PlaySupportSpec.scala
+++ b/core/src/test/scala/toguru/play/PlaySupportSpec.scala
@@ -4,7 +4,8 @@ import java.util.UUID
 
 import akka.util.Timeout
 import org.scalatest.OptionValues._
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import play.api.http.HttpVerbs
 import play.api.test.{FakeRequest, Helpers}
 import toguru.api._
@@ -14,7 +15,7 @@ import toguru.test.TestActivations
 import scala.concurrent.duration._
 import scala.language.implicitConversions
 
-class PlaySupportSpec extends WordSpec with MustMatchers with RequestHelpers with ControllerHelpers {
+class PlaySupportSpec extends AnyWordSpec with Matchers with RequestHelpers with ControllerHelpers {
 
   "toguruClient method" should {
     "create a PlayToguruClient" in {

--- a/core/src/test/scala/toguru/test/TestActivationsSpec.scala
+++ b/core/src/test/scala/toguru/test/TestActivationsSpec.scala
@@ -1,9 +1,10 @@
 package toguru.test
 
-import org.scalatest._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import toguru.api._
 
-class TestActivationsSpec extends WordSpec with MustMatchers {
+class TestActivationsSpec extends AnyWordSpec with Matchers {
 
   "healthy" should {
     "always return true" in {


### PR DESCRIPTION
 * Remove two unused dependencies (`scalactic` and `commons-io`)
 * Update patch versions of scala and compile dependencies
 * Update test dependencies to the latest versions

I haven't updated `http4s` as it requires code changes, and I'm thinking of replacing the tests that start a real HTTP server with something more lightweight like `sttp` stubs.