### PR TITLE
Use SLF4J directly instead of scala-logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val core = projectMatrix
     ),
     libraryDependencies ++= Seq(
       "com.softwaremill.sttp.client" %% "core"                        % "2.0.0-RC6",
-      "com.typesafe.scala-logging"   %% "scala-logging"               % "3.5.0",
+      "org.slf4j"                    % "slf4j-api"                    % "1.7.30",
       "org.komamitsu"                % "phi-accural-failure-detector" % "0.0.5",
       "com.hootsuite"                %% "scala-circuit-breaker"       % "1.0.5",
       "org.mockito"                  %% "mockito-scala-scalatest"     % "1.10.0" % "test",


### PR DESCRIPTION
We use logging very little in the code, so to avoid additional dependencies we can use slf4j api directly.