### PR TITLE
Drop Scala 2.11 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,12 +46,11 @@ lazy val core = projectMatrix
     )
   )
   .jvmPlatform(
-    scalaVersions = Seq("2.12.10", "2.11.12"),
+    scalaVersions = Seq("2.12.10"),
     settings = Seq(
       libraryDependencies ++= {
         val (playVersion, playJsonVersion) = scalaBinaryVersion.value match {
           case "2.12" => ("2.6.25", "2.6.14")
-          case "2.11" => ("2.5.19", "2.5.19")
         }
         Seq(
           "com.typesafe.play" %% "play-json" % playJsonVersion,


### PR DESCRIPTION
Going forward we will need to cross-build for Scala 2.13 and probably for different Play Framework versions. Maintaining compatibility with Scala 2.11 increases the effort.

I propose the declare the current `2.0.0` as the last version supporting 2.11.