### PR TITLE
Use circe instead of play-json

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,13 +49,14 @@ lazy val core = projectMatrix
     scalaVersions = Seq("2.12.10"),
     settings = Seq(
       libraryDependencies ++= {
-        val (playVersion, playJsonVersion) = scalaBinaryVersion.value match {
-          case "2.12" => ("2.6.25", "2.6.14")
+        val (playVersion, circeVersion) = scalaBinaryVersion.value match {
+          case "2.12" => ("2.6.25", "0.12.3")
         }
         Seq(
-          "com.typesafe.play" %% "play-json" % playJsonVersion,
-          "com.typesafe.play" %% "play"      % playVersion % "optional",
-          "com.typesafe.play" %% "play-test" % playVersion % "test"
+          "io.circe"          %% "circe-core"   % circeVersion,
+          "io.circe"          %% "circe-parser" % circeVersion,
+          "com.typesafe.play" %% "play"         % playVersion % "optional",
+          "com.typesafe.play" %% "play-test"    % playVersion % "test"
         )
       }
     )

--- a/core/src/main/scala/toguru/impl/ToggleStates.scala
+++ b/core/src/main/scala/toguru/impl/ToggleStates.scala
@@ -30,6 +30,7 @@ object ToggleState {
 
     new ToggleState(id, tags, condition)
   }
+
 }
 
 case class ToggleActivation(rollout: Option[Rollout] = None, attributes: Map[String, Seq[String]] = Map.empty)


### PR DESCRIPTION
Using `play-json` as a JSON library makes it challenging to cross-build for different Play versions, especially if we want to have a "core" version of the scala client that doesn't depend on Play at all.

As a side-effect of this change, I dropped support for v1 and v2 response formats. Toguru uses v3 since 2017, if someone needs to work with the older toguru server, they will have to use toguru-scala-client 2.x.