### PR TITLE
Depend on request header when possible

### DIFF
--- a/play/src/main/scala/toguru/play/package.scala
+++ b/play/src/main/scala/toguru/play/package.scala
@@ -5,9 +5,9 @@ import toguru.api.{Activations, ClientInfo, Toggling, ToguruClient}
 
 package object play {
 
-  type PlayToguruClient = ToguruClient[Request[_]]
+  type PlayToguruClient = ToguruClient[RequestHeader]
 
-  type PlayClientProvider = ClientInfo.Provider[Request[_]]
+  type PlayClientProvider = ClientInfo.Provider[RequestHeader]
 
   class ToggledRequest[A](val client: ClientInfo, val activations: Activations, request: Request[A])
       extends WrappedRequest[A](request)


### PR DESCRIPTION
We don't need to depend on the full `Request`. Using `RequestHeader` makes it possible to use the client in Play filters.

Supersedes #30.