### PR TITLE
Drop SNAPSHOT suffix from the version string

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,8 @@ ThisBuild / licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
 ThisBuild / bintrayOrganization := Some("autoscout24")
 
 ThisBuild / gitVersioningSnapshotLowerBound := "3.0.0"
+// Snapshots cannot be published on BinTray
+ThisBuild / version := (ThisBuild / version).value.replaceAll("\\-SNAPSHOT$", "")
 
 ThisBuild / resolvers ++= Seq(
   Resolver.jcenterRepo,


### PR DESCRIPTION
BinTray does not allow SNAPSHOT versions