### PR TITLE
Mark everything private as private

### DIFF
--- a/core/src/main/scala/toguru/impl/Conditions.scala
+++ b/core/src/main/scala/toguru/impl/Conditions.scala
@@ -5,19 +5,19 @@ import java.util.UUID
 
 import toguru.api.{ClientInfo, Condition}
 
-case object AlwaysOnCondition extends Condition {
+private[toguru] case object AlwaysOnCondition extends Condition {
   override def applies(clientInfo: ClientInfo): Boolean = true
 }
 
-case object AlwaysOffCondition extends Condition {
+private[toguru] case object AlwaysOffCondition extends Condition {
   override def applies(clientInfo: ClientInfo): Boolean = false
 }
 
-case class All(conditions: Set[Condition]) extends Condition {
+private[toguru] case class All(conditions: Set[Condition]) extends Condition {
   override def applies(clientInfo: ClientInfo) = conditions.forall(_.applies(clientInfo))
 }
 
-case class Attribute(name: String, values: Seq[String]) extends Condition {
+private[toguru] case class Attribute(name: String, values: Seq[String]) extends Condition {
   override def applies(clientInfo: ClientInfo) = clientInfo.attributes.get(name).exists(values.contains)
 }
 
@@ -27,7 +27,7 @@ case class Attribute(name: String, values: Seq[String]) extends Condition {
   * @param f      a function that projects an UUID to an Int in the range between 1 and 100
   * @param ranges ranges from 1 to 100 (inclusive) that f(uuid) has to land in so that this condition will be true for the client uuid
   */
-case class UuidDistributionCondition(ranges: Seq[Range], f: UUID => Int) extends Condition {
+private[toguru] case class UuidDistributionCondition(ranges: Seq[Range], f: UUID => Int) extends Condition {
 
   ranges.foreach(r =>
     if (r.head < 1 || r.last > 100)
@@ -45,11 +45,11 @@ case class UuidDistributionCondition(ranges: Seq[Range], f: UUID => Int) extends
     }
 }
 
-object UuidDistributionCondition {
+private[toguru] object UuidDistributionCondition {
 
   def apply(range: Range, f: UUID => Int = defaultUuidToIntProjection): UuidDistributionCondition = apply(Seq(range), f)
 
-  val defaultUuidToIntProjection: UUID => Int = { (uuid) =>
+  val defaultUuidToIntProjection: UUID => Int = { uuid =>
     val hibits   = uuid.getMostSignificantBits
     val lobits   = uuid.getLeastSignificantBits
     val barrayHi = BigInteger.valueOf(hibits).toByteArray

--- a/core/src/main/scala/toguru/impl/ToggleStates.scala
+++ b/core/src/main/scala/toguru/impl/ToggleStates.scala
@@ -39,9 +39,9 @@ case class Rollout(percentage: Int)
 
 class ToggleStateActivations(toggleStates: ToggleStates) extends Activations {
 
-  val conditions = toggleStates.toggles.map(ts => ts.id -> ts.condition).toMap
+  private val conditions = toggleStates.toggles.map(ts => ts.id -> ts.condition).toMap
 
-  override def apply(toggle: Toggle) = conditions.getOrElse(toggle.id, toggle.default)
+  override def apply(toggle: Toggle): Condition = conditions.getOrElse(toggle.id, toggle.default)
 
   override def apply(): Iterable[ToggleState] = toggleStates.toggles
 

--- a/core/src/main/scala/toguru/test/TestActivations.scala
+++ b/core/src/main/scala/toguru/test/TestActivations.scala
@@ -1,5 +1,6 @@
 package toguru.test
 
+import toguru.api.Toggle.ToggleId
 import toguru.api.{Activations, Condition, Toggle}
 import toguru.impl.ToggleState
 
@@ -8,17 +9,19 @@ import toguru.impl.ToggleState
   */
 object TestActivations {
 
-  def apply(activations: (Toggle, Condition)*)(services: (Toggle, String)*) = new Activations.Provider() {
-    override def apply() = new Impl(activations: _*)(services: _*)
+  def apply(activations: (Toggle, Condition)*)(services: (Toggle, String)*): Activations.Provider =
+    new Activations.Provider() {
+      override def apply() = new Impl(activations: _*)(services: _*)
 
-    override def healthy() = true
-  }
+      override def healthy() = true
+    }
 
-  class Impl(activations: (Toggle, Condition)*)(services: (Toggle, String)*) extends Activations {
+  private[toguru] class Impl(activations: (Toggle, Condition)*)(services: (Toggle, String)*) extends Activations {
 
-    override def apply(toggle: Toggle) = activations.collectFirst { case (`toggle`, c) => c }.getOrElse(toggle.default)
+    override def apply(toggle: Toggle): Condition =
+      activations.collectFirst { case (`toggle`, c) => c }.getOrElse(toggle.default)
 
-    override def apply() = (activations.map(_._1) ++ services.map(_._1)).distinct.map { t =>
+    override def apply(): Seq[ToggleState] = (activations.map(_._1) ++ services.map(_._1)).distinct.map { t =>
       new ToggleState(
         t.id,
         services.find(_._1 == t).map("service" -> _._2).toMap,
@@ -26,7 +29,8 @@ object TestActivations {
       )
     }
 
-    override def togglesFor(service: String) = services.collect { case (t, `service`) => t.id -> apply(t) }.toMap
+    override def togglesFor(service: String): Map[ToggleId, Condition] =
+      services.collect { case (t, `service`) => t.id -> apply(t) }.toMap
 
     override def stateSequenceNo: Option[Long] = None
   }


### PR DESCRIPTION
To make it easier to maintain binary compatibility let's try to hide library internals.