### PR TITLE
Exclude logback from test dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,8 +35,8 @@ val versions = new {
 
 val dependencies = new {
   def play(version: String) = Seq(
-    "com.typesafe.play" %% "play"      % version % Provided,
-    "com.typesafe.play" %% "play-test" % version % Test,
+    "com.typesafe.play" %% "play" % version % Provided,
+    ("com.typesafe.play" %% "play-test" % version % Test).exclude("ch.qos.logback", "logback-classic"),
   )
 }
 


### PR DESCRIPTION
We have the `nop` logging implementation in tests and don't need `logback` as a second one.